### PR TITLE
Catching exception from GET request containing non-numerical HTTP-version number

### DIFF
--- a/server_http.hpp
+++ b/server_http.hpp
@@ -357,6 +357,7 @@ namespace SimpleWeb {
                     if(!ec) {
                         if(timeout_content>0)
                             timer->cancel();
+                        try {
                         auto http_version=stof(request->http_version);
                         
                         auto range=request->header.equal_range("Connection");
@@ -366,6 +367,8 @@ namespace SimpleWeb {
                         }
                         if(http_version>1.05)
                             read_request_and_content(response->socket);
+                    } catch(std::exception e) {
+                    }
                     }
                 });
             });


### PR DESCRIPTION
This closes issue #15 