### PR TITLE
Changed http_version type to float

### DIFF
--- a/server_http.hpp
+++ b/server_http.hpp
@@ -357,7 +357,7 @@ namespace SimpleWeb {
                     if(!ec) {
                         if(timeout_content>0)
                             timer->cancel();
-                        auto http_version=stof(request->http_version);
+                        float http_version=stof(request->http_version);
                         
                         auto range=request->header.equal_range("Connection");
                         for(auto it=range.first;it!=range.second;it++) {


### PR DESCRIPTION
Previously the http_version variable could be set to any value, which caused a crash in cases where it contained string characters.