### PR TITLE
Solved server crash when GET request HTTP version cannot be parsed by stof

### DIFF
--- a/server_http.hpp
+++ b/server_http.hpp
@@ -357,15 +357,19 @@ namespace SimpleWeb {
                     if(!ec) {
                         if(timeout_content>0)
                             timer->cancel();
-                        auto http_version=stof(request->http_version);
+                        try{
+                            auto http_version=stof(request->http_version);
                         
-                        auto range=request->header.equal_range("Connection");
-                        for(auto it=range.first;it!=range.second;it++) {
-                            if(boost::iequals(it->second, "close"))
-                                return;
+                            auto range=request->header.equal_range("Connection");
+                            for(auto it=range.first;it!=range.second;it++) {
+                                if(boost::iequals(it->second, "close"))
+                                    return;
+                            }
+                            if(http_version>1.05)
+                                read_request_and_content(response->socket);
+                        } catch ( ... ){
+                            return;
                         }
-                        if(http_version>1.05)
-                            read_request_and_content(response->socket);
                     }
                 });
             });


### PR DESCRIPTION
Wrapped the parsing method with try catch.
In cases where an error occurred the connection will terminate but the server will remain running.