### PR TITLE
Fixed server crash when presented with an invalid HTTP version. Fix for Issue #56

### DIFF
--- a/server_http.hpp
+++ b/server_http.hpp
@@ -357,7 +357,17 @@ namespace SimpleWeb {
                     if(!ec) {
                         if(timeout_content>0)
                             timer->cancel();
-                        auto http_version=stof(request->http_version);
+                        
+                        float http_version;
+                          try {
+                            http_version=stof(request->http_version);
+                        }
+                        catch(const std::exception e) {
+                            if (exception_handler) {
+                                exception_handler(e);
+                            }
+                            return;
+                        }
                         
                         auto range=request->header.equal_range("Connection");
                         for(auto it=range.first;it!=range.second;it++) {


### PR DESCRIPTION
Added a try/catch in server_http.hpp