### PR TITLE
Fixed invalid HTTP version / syntax causes server crash

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,13 +6,23 @@ using namespace std;
 
 int main() {
   // Construct HTTP-server at port 8080 using 1 thread, and without request timeout
-  HttpServer server(8080, 1, 0);
+  HttpServer server(8090, 1, 0);
 
   // Response to all GET requests
+  
   server.resource["^.*$"]["GET"] = [](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+    
+    
+    cout << "Path: " << request -> path << endl;
+    cout << "Version: " << request -> http_version << endl;
+
     std::string content = "<h1>The web server is working!</h1>";
     *response << "HTTP/1.1 200 OK\r\nContent-Length: " << content.length() << "\r\n\r\n" << content;
+    
   };
-
+  
+  cout << "Started server @ " << server.config.port<< endl;
   server.start();
+  
+  cout << "Server stopped" << endl;
 }

--- a/server_http.hpp
+++ b/server_http.hpp
@@ -283,20 +283,46 @@ namespace SimpleWeb {
         }
 
         bool parse_request(std::shared_ptr<Request> request, std::istream& stream) const {
+            
             std::string line;
+            
             getline(stream, line);
-            size_t method_end;
-            if((method_end=line.find(' '))!=std::string::npos) {
-                size_t path_end;
-                if((path_end=line.find(' ', method_end+1))!=std::string::npos) {
-                    request->method=line.substr(0, method_end);
-                    request->path=line.substr(method_end+1, path_end-method_end-1);
+            
+            size_t method_end =line.find(' ');
+            
+            if( method_end != std::string::npos) {
+                
+                size_t path_end = line.find(' ', method_end+1);
+                
+                if(path_end != std::string::npos) {
+                    
+                    request -> method = line.substr(0, method_end);
+                    request -> path = line.substr(method_end+1, path_end-method_end-1);
 
-                    size_t protocol_end;
-                    if((protocol_end=line.find('/', path_end+1))!=std::string::npos) {
-                        if(line.substr(path_end+1, protocol_end-path_end-1)!="HTTP")
+                    size_t protocol_end = line.find('/', path_end+1);
+                    
+                    //std::cout << line << std::endl;
+                    
+                    std::string protocol = "";
+                    
+                    int i = 1;
+                    char current = line[path_end+i];
+                    
+                    // leser til slutten av HTTP/1.1, siden .length og greier ikke fungerte
+                    // Fikk det ikke til med substring, fikk noe newline tull på slutten
+                    while(isalpha(current) || isdigit(current) || current == '.' || current == '/'){
+                        protocol = protocol+current; // legger til neste char
+                        current = line[path_end + ++i]; // henter neste char
+                    }
+                    
+                    //std::cout << "Protocol: " << protocol << " - Line: "<< line << std::endl;
+                                             
+                    if(protocol_end != std::string::npos) {
+                        
+                        if( protocol != "HTTP/1.1" && protocol != "HTTP/1.0")
                             return false;
-                        request->http_version=line.substr(protocol_end+1, line.size()-protocol_end-2);
+                        
+                        request -> http_version = line.substr(protocol_end+1, line.size()-protocol_end-2);
                     }
                     else
                         return false;


### PR DESCRIPTION
Issue #1 fix.

Fixed by checking if request contains "HTTP/1.1" or "HTTP/1.0" specifically. You can no longer crash the server as described in #1.

- Olav Reppe Husby